### PR TITLE
Fix Enter key behavior and preserve logic for checkbox handlers

### DIFF
--- a/src/FormInteraction.ts
+++ b/src/FormInteraction.ts
@@ -56,6 +56,18 @@ export class FormInteraction {
     this.shirtDesign.addEventListener('change', this.updateShirtColor.bind(this));
     this.activities.addEventListener('change', this.updateActivitiesCost.bind(this));
     this.payment.addEventListener('change', this.updatePaymentInfo.bind(this));
+
+    // Prevent form submission when Enter is pressed while a checkbox is focused
+    this.activitiesCheckboxes.forEach(checkbox => {
+      checkbox.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'Enter') {
+          checkbox.checked = !checkbox.checked; // Toggle checkbox state
+          this.updateActivitiesCost(e); // Updates the total price
+          this.toggleDisabledActivities(checkbox); // Disables any activities where date/time conflicts
+          e.preventDefault(); // Prevent the form submission
+        }
+      });
+    });
   }
 
   /**


### PR DESCRIPTION
### Description:
This pull request fixes an issue where pressing the Enter key while a checkbox is in focus would submit the form instead of toggling the checkbox state. 

Additionally, the following improvements have been made:
- The event handler for activities checkboxes now includes the necessary arguments for `updateActivitiesCost()` and `toggleDisabledActivities()`, ensuring that the logic is preserved.
- Added an event listener to prevent form submission when the Enter key is pressed, allowing toggling the checkbox and updating the total cost.

### How to test:
1. Focus on a checkbox.
2. Press the Enter key and verify the checkbox toggles without submitting the form.
3. Check that the total cost and conflicting activities are updated correctly.
