### PR TITLE
Fix issue #8: Payment Info Visibility on Page Load

### DIFF
--- a/src/FormInteraction.ts
+++ b/src/FormInteraction.ts
@@ -39,9 +39,7 @@ export class FormInteraction {
   }
 
   /**
-   * Set the initial form state, including hiding/showing fields and setting focus.
-   * @param otherJobRole - The "Other Job Role" input field to manage visibility
-   * @param shirtColor - The shirt color selection dropdown to manage state
+   * Initialize the form state, including the payment info section.
    */
   public initializeFormState(
     otherJobRole: HTMLInputElement, 
@@ -54,8 +52,11 @@ export class FormInteraction {
     // Disable shirt color selection until a design is chosen
     shirtColor.disabled = true;
 
-    // Automatically focus on the name inut for user convenience
+    // Automatically focus on the name input for user convenience
     nameInput.focus(); 
+
+    // Initialize payment info visibility
+    this.updatePaymentInfo();
   }
 
   /**
@@ -163,16 +164,17 @@ export class FormInteraction {
 
   /**
    * Show the appropriate payment method details based on the selected option
+   * and hide others during initialization.
    * @param e - The change event from the payment method dropdown
    */
-  updatePaymentInfo(e: Event): void {
+  updatePaymentInfo(e?: Event): void {
     // Hide all payment options initially
     this.paymentMethods.creditCard.style.display = 'none';
     this.paymentMethods.paypal.style.display = 'none';
     this.paymentMethods.bitcoin.style.display = 'none';
 
-    // Show the selected payment method details
-    const target = e.target as HTMLSelectElement;
+    // Determine the selected payment method
+    const target = e ? (e.target as HTMLSelectElement) : this.payment;
     const selectedPayment = document.getElementById(target.value);
 
     if (selectedPayment) {


### PR DESCRIPTION
### Problem
When the form is loaded, the phrases for PayPal and Bitcoin payment methods are visible by default, even when "Credit Card" is selected as the default payment option. Users must select a different payment method and reselect "Credit Card" to hide the unnecessary phrases.  

### Solution
- Updated the `updatePaymentInfo` method to ensure only the selected payment method's information is visible on page load.
- Added an initialization step to set the correct visibility for payment method details when the page first loads.

### Changes Made
- Modified the `initializeFormState` method to set the visibility of payment method elements on page load.
- Ensured the default "Credit Card" payment method hides information related to other payment methods on initialization.

### Testing
- Verified that only the relevant payment method information is displayed when each method is selected.
- Tested that no unnecessary phrases are visible when "Credit Card" is selected by default.
- Confirmed that switching between payment methods works as expected.

### Related Issue
Resolves Issue #8
